### PR TITLE
Correct an AmbiguousMatchException with hidden members

### DIFF
--- a/SparkyTestHelpers.Mapping.UnitTests/MapTesterTests.cs
+++ b/SparkyTestHelpers.Mapping.UnitTests/MapTesterTests.cs
@@ -133,6 +133,22 @@ namespace SparkyTestHelpers.Mapping.UnitTests
                 .AssertMappedValues(input, output);
         }
 
+        [TestMethod]
+        public void HiddenProperty_should_resolve_to_top_most_member()
+        {
+            var restaurantEditModel = new RestaurantEditModel {Cuisine = CuisineType.Italian, Name = "Test name"};
+            var restaurantModel = new Restaurant {Cuisine = CuisineType.Italian, Name = "Test name"};
+
+            var restaurantList = new RestauranstList {Restaurants = new[] {restaurantModel}};
+            var editRestaurantList = new RestaurantEditList {Restaurants = new[] {restaurantEditModel}};
+
+            MapTester.ForMap<RestauranstList, RestaurantEditList>()
+                .WithLogging()
+                .IgnoringMember(dest => dest.Restaurants)
+                .AssertMappedValues(restaurantList, editRestaurantList);
+            
+        }
+
         private void AssertMappedValues()
         {
             AssertExceptionNotThrown.WhenExecuting(() => _mapTester.AssertMappedValues(_source, _dest));

--- a/SparkyTestHelpers.Mapping.UnitTests/MapTesterTests.cs
+++ b/SparkyTestHelpers.Mapping.UnitTests/MapTesterTests.cs
@@ -143,10 +143,9 @@ namespace SparkyTestHelpers.Mapping.UnitTests
             var editRestaurantList = new RestaurantEditList {Restaurants = new[] {restaurantEditModel}};
 
             MapTester.ForMap<RestauranstList, RestaurantEditList>()
-                .WithLogging()
+                // ignored since the internal constructor of MapTester is what's being tested
                 .IgnoringMember(dest => dest.Restaurants)
                 .AssertMappedValues(restaurantList, editRestaurantList);
-            
         }
 
         private void AssertMappedValues()

--- a/SparkyTestHelpers.Mapping.UnitTests/PropertyInfoResolverTests.cs
+++ b/SparkyTestHelpers.Mapping.UnitTests/PropertyInfoResolverTests.cs
@@ -1,0 +1,35 @@
+﻿using System.Linq;
+using System.Reflection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SparkyTestHelpers.Mapping.UnitTests.TestClasses;
+
+namespace SparkyTestHelpers.Mapping.UnitTests
+{    
+    [TestClass]
+    public class PropertyInfoResolverTests
+    {
+        [TestMethod]
+        public void OverridenProperty_should_throw_ambiguous_exception()
+        {
+            Assert.ThrowsException<AmbiguousMatchException>(() =>
+                typeof(RestaurantEditList).GetProperty(nameof(RestaurantEditList.Restaurants)));
+        }
+
+        [TestMethod]
+        public void OverridenProperty_should_resolve_with_GetProperties_First()
+        {
+            var propertyInfo = typeof(RestaurantEditList).GetProperties()
+                .First(property => property.Name == nameof(RestaurantEditList.Restaurants));
+            
+            Assert.AreEqual(propertyInfo.PropertyType, typeof(RestaurantEditModel[]));
+        }
+
+        [TestMethod]
+        public void PropertyInfoResolver_can_resolve_hidden_property()
+        {
+            var propertyInfo = PropertyInfoResolver.Instance.ResolveProperty(typeof(RestaurantEditList).GetTypeInfo(),
+                nameof(RestaurantEditList.Restaurants));
+            Assert.AreEqual(propertyInfo.PropertyType, typeof(RestaurantEditModel[]));
+        }
+    }
+}

--- a/SparkyTestHelpers.Mapping.UnitTests/SparkyTestHelpers.Mapping.UnitTests.csproj
+++ b/SparkyTestHelpers.Mapping.UnitTests/SparkyTestHelpers.Mapping.UnitTests.csproj
@@ -1,19 +1,14 @@
-<Project Sdk="Microsoft.NET.Sdk">
-
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
-
     <IsPackable>false</IsPackable>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.2.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.2.0" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\SparkyTestHelpers.Mapping\SparkyTestHelpers.Mapping.csproj" />
   </ItemGroup>
-
 </Project>

--- a/SparkyTestHelpers.Mapping.UnitTests/TestClasses/RestaurantEditList.cs
+++ b/SparkyTestHelpers.Mapping.UnitTests/TestClasses/RestaurantEditList.cs
@@ -1,0 +1,8 @@
+﻿namespace SparkyTestHelpers.Mapping.UnitTests.TestClasses
+{
+    public class RestaurantEditList : RestauranstList
+    {
+        // required to create multiple property types for the PropertyInfoResolverTests
+        public new RestaurantEditModel[] Restaurants { get; set; }
+    }
+}

--- a/SparkyTestHelpers.Mapping.UnitTests/TestClasses/RestaurantLists.cs
+++ b/SparkyTestHelpers.Mapping.UnitTests/TestClasses/RestaurantLists.cs
@@ -1,0 +1,7 @@
+﻿namespace SparkyTestHelpers.Mapping.UnitTests.TestClasses
+{
+    public class RestauranstList
+    {
+        public Restaurant[] Restaurants { get; set; }
+    }
+}

--- a/SparkyTestHelpers.Mapping/MapTester.cs
+++ b/SparkyTestHelpers.Mapping/MapTester.cs
@@ -46,9 +46,9 @@ namespace SparkyTestHelpers.Mapping
 
             foreach (string propertyName in commonPropertyNames)
             {
-                PropertyInfo srcProperty = sourceTypeInfo.GetProperty(propertyName);
-                PropertyInfo destProperty = destTypeInfo.GetProperty(propertyName);
-
+                PropertyInfo srcProperty = PropertyInfoResolver.Instance.ResolveProperty(sourceTypeInfo, propertyName);
+                PropertyInfo destProperty = PropertyInfoResolver.Instance.ResolveProperty(destTypeInfo, propertyName);
+              
                 SetTesterForProperty(propertyName,
                     new MapMemberTester<TSource, TDestination>(
                         this,
@@ -56,6 +56,7 @@ namespace SparkyTestHelpers.Mapping
                         src => srcProperty.GetValue(src, null)));
             }
         }
+        
 
         /// <summary>
         /// Log destination property values when <see cref="AssertMappedValues(TSource, TDestination)"/> is called.

--- a/SparkyTestHelpers.Mapping/PropertyInfoResolver.cs
+++ b/SparkyTestHelpers.Mapping/PropertyInfoResolver.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+
+namespace SparkyTestHelpers.Mapping
+{
+    public class PropertyInfoResolver
+    {
+        public static PropertyInfoResolver Instance => LazyResolver.Value;
+
+        private static readonly Lazy<PropertyInfoResolver> LazyResolver = new Lazy<PropertyInfoResolver>(() => new PropertyInfoResolver());
+        
+        private PropertyInfoResolver()
+        {
+            // singleton pattern, external code shouldn't call the constructor
+        }
+        
+        public PropertyInfo ResolveProperty(TypeInfo typeInfo, string propertyName)
+        {
+            try
+            {
+                return typeInfo.GetProperty(propertyName);
+            }
+            catch (AmbiguousMatchException e)
+            {
+                var ambiguousProperty = typeInfo.GetProperties().First(property => property.Name == propertyName);
+                //can't use _log here since it hasn't been configured yet.
+                Console.WriteLine($"{e.GetType().FullName}: A property was hidden by a derived class.  Selecting: '{typeInfo.FullName}: {ambiguousProperty.PropertyType.FullName}' for '{propertyName}'.");
+                return ambiguousProperty;
+            }
+        }
+        
+    }
+}

--- a/SparkyTestHelpers.Mapping/SparkyTestHelpers.Mapping.csproj
+++ b/SparkyTestHelpers.Mapping/SparkyTestHelpers.Mapping.csproj
@@ -1,5 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
-
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard1.5</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
@@ -17,13 +16,10 @@
     <FileVersion>1.2.2.0</FileVersion>
     <Version>1.2.2</Version>
   </PropertyGroup>
-
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DocumentationFile>bin\Release\netstandard2.0\SparkyTestHelpers.Mapping.xml</DocumentationFile>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="SparkyTestHelpers" Version="1.2.2" />
   </ItemGroup>
-
 </Project>

--- a/SparkyTestHelpers.Scenarios.MsTest/SparkyTestHelpers.Scenarios.MsTest.csproj
+++ b/SparkyTestHelpers.Scenarios.MsTest/SparkyTestHelpers.Scenarios.MsTest.csproj
@@ -1,5 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
-
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard1.3</TargetFramework>
     <Authors>Brian Schroer</Authors>
@@ -17,14 +16,13 @@
     <AssemblyVersion>1.2.1.0</AssemblyVersion>
     <FileVersion>1.2.1.0</FileVersion>
   </PropertyGroup>
-
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DocumentationFile>bin\Release\netstandard2.0\SparkyTestHelpers.MsTest.xml</DocumentationFile>
   </PropertyGroup>
-
   <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="1.2.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.2.0" />
     <PackageReference Include="SparkyTestHelpers" Version="1.2.2" />
   </ItemGroup>
-
 </Project>


### PR DESCRIPTION
This corrects an issue when a `ClassB` inherits `ClassA`, and `ClassB` overrides a member of `ClassA` by using the `new` keyword.

For example:
```c#
public class ClassA
{
  public int foo { get; set; }
}

public class ClassB
{
  public new decimal foo { get; set; }
}
```

When you call:
`typeof(ClassB).GetProperty("foo")` a `System.Reflection.AmbiguousMatchException` is thrown since it can't resolve which it is.

The proposed solution will use `typeof(ClassB).GetProperties().First(p => p.Name == "foo")`.

There are tests to cover the issue and the solution.

The addition of the two packages, was required to let Rider run all the tests in `SparkyTestHelpers.Scenarios.MsTest`
```
<PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.0" />
<PackageReference Include="MSTest.TestAdapter" Version="1.2.0" />
```